### PR TITLE
Internationalize content interpolation error

### DIFF
--- a/app/models/sendgrid_notification/notification_mail.rb
+++ b/app/models/sendgrid_notification/notification_mail.rb
@@ -30,7 +30,7 @@ module SendgridNotification
         params[key] || params[key.to_sym] || unresolved.push(key)
       }
       if unresolved.present?
-        errors.add(:content, :unresolved, message: "have unresolved variables: #{unresolved.join(",")}")
+        errors.add(:content, :unresolved_template_parameters, variables: unresolved.join(","))
       end
       body
     end

--- a/test/dummy/config/locales/active_record.en.yml
+++ b/test/dummy/config/locales/active_record.en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  activerecord:
+    errors:
+      models:
+        sendgrid_notification/notification_mail_subclass_test/example_mail:
+          attributes:
+            content:
+              unresolved_template_parameters: "has unresolved variables: %{variables}"

--- a/test/models/sendgrid_notification/notification_mail_subclass_test.rb
+++ b/test/models/sendgrid_notification/notification_mail_subclass_test.rb
@@ -23,7 +23,7 @@ module SendgridNotification
       assert { ExampleMail.new.key == 'registration' }
     end
 
-    test 'validates content can recieve parameters and no unresolved variables remains' do
+    test 'validates that content can receive parameters and that no unresolved variables remain' do
       @m = ExampleMail.first
       assert { @m.valid? }
 
@@ -35,9 +35,11 @@ module SendgridNotification
 
       @m.content = '[{{ name }}]{{ email }} {{ tel }}'
       assert { @m.invalid? }
+      assert_equal 'has unresolved variables: tel', @m.errors[:content].first
 
       @m.content = '[{{ name0 }}]{{ email }}'
       assert { @m.invalid? }
+      assert_equal 'has unresolved variables: name0', @m.errors[:content].first
 
       # base class has no validations about content
       base = @m.becomes(NotificationMail)


### PR DESCRIPTION
The error in `#apply` always comes back as `have unresolved variables:` even after adding the `errors.messages.unresolved` key to my locale files.

I made these changes:

1. Rename the error key `unresolved` to something less likely to overlap with keys defined in the application.
2. Rename the `message` option. [ActiveModel::Errors#generate_message](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/errors.rb#L398) overrides the error key when supplied with a `message` option.