### PR TITLE
Fix `invalid option: --guard (OptionParser::InvalidOption)`

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard :minitest do
+guard :minitest, spring: 'bin/rails test' do
   # with Minitest::Unit
   watch(%r{^test/(.*)_test\.rb$})
   watch(%r{^app/(.*/)?([^/]+)\.rb$}) { |m| "test/#{m[1]}#{m[2]}_test.rb" }


### PR DESCRIPTION
I get this error when I try to run guard:

```
$ rbenv exec bundle exec guard
11:45:01 - INFO - Guard::Minitest 2.4.6 is running, with Minitest::Unit 5.10.3!
11:45:01 - INFO - Running: all tests
/Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/railties-5.1.2/lib/rails/test_unit/minitest_plugin.rb:62:in `plugin_rails_options': invalid option: --guard (OptionParser::InvalidOption)
        from /Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.3/lib/minitest.rb:201:in `block (2 levels) in process_args'
        from /Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.3/lib/minitest.rb:199:in `each'
        from /Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.3/lib/minitest.rb:199:in `block in process_args'
        from /Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.3/lib/minitest.rb:169:in `new'
        from /Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.3/lib/minitest.rb:169:in `process_args'
        from /Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.3/lib/minitest.rb:123:in `run'
        from /Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/railties-5.1.2/lib/rails/test_unit/minitest_plugin.rb:77:in `run'
        from /Users/rastam/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.3/lib/minitest.rb:63:in `block in autorun'
```

According to https://github.com/guard/guard-minitest/issues/142 this is an issue with Rails 5.
Guard works after adding the settings specified in the issue.