### PR TITLE
Change NotificationMail#key uniqueness validator case_sensitive option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [0.2.1]
+
+### Changes
+
+- (Breaking changes) Change uniqueness validator case_sensitive option
+  - `case_sensitive: false`
+  - required for `rails >= 6`
+
 ## [0.2.0]
 
 ### New Features

--- a/app/models/sendgrid_notification/notification_mail.rb
+++ b/app/models/sendgrid_notification/notification_mail.rb
@@ -2,7 +2,7 @@ module SendgridNotification
   class NotificationMail < ActiveRecord::Base
 
     with_options presence: true do
-      validates :key, uniqueness: true
+      validates :key, uniqueness: { case_sensitive: false }
       validates :subject
       validates :content
     end

--- a/lib/sendgrid_notification/version.rb
+++ b/lib/sendgrid_notification/version.rb
@@ -1,3 +1,3 @@
 module SendgridNotification
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
 end


### PR DESCRIPTION
required for `rails >= 6.1`. warning in 6.0: 

> WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :key attribute in SendgridNotification::NotificationMail model, pass `case_sensitive: true` option explicitly to the uniqueness validator.